### PR TITLE
First drop of Dev Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ crash.log
 
 # For built boxes
 *.box
+
+# Mac OS X files
+.DS_Store

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -64,7 +64,7 @@ This means also that SSH keys can go into the user's SSH directory like normal.
 * Bind mount in host Git config
   * Support the location of this config for both Mac, Liux & Windows
 * Bind mount in SSH keys
-  * * Support the location of this config for both Mac, Liux & Windows
+  * Support the location of this config for both Mac, Liux & Windows
 * Ensure that we can utilise Git from within the Dev Container
 
 ## Building Requiremets
@@ -83,7 +83,6 @@ What sort of things will I need to setup in the `devcontainer.json` file?
 ## Questions
 
 * How do you bind mount in the Docker Socket on Windows so that Docker in Docker (DooD) works?
-* 
 
 ## Tutorials
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,11 +6,25 @@ This Docker image will be a heavy weight image, approximately 600MB
 
 All this should be put into one of my own GitHub repos, so I can maintain the files correctly, and can easily rebuild things when I get new laptops.
 
+## Pre-requisites
+To be able to utilise this, the following pre-requisites need to be satisfied:
+
+* VS Code installed
+* Remote Containers extension installed
+* Docker Desktop installed
+
+## Useful Documentation on Remote Contaiers
+
+* [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers)
+* [Getting Started with development in Containers](https://code.visualstudio.com/docs/remote/containers-tutorial)
+* [Create a development container](https://code.visualstudio.com/docs/remote/create-dev-container)
+* [Advanced development container configuration](https://code.visualstudio.com/remote/advancedcontainers/overview)
+
 ## Main Requirements
 
 * Based on Alpine 3
 * Start from the official "Docker in Docker" image (provided by Docker)
-  * Fortuately this is based on Alpine 3, and will save me a lot of work ennsuring Docker works correctly
+  * Fortunately this is based on Alpine 3, and will save me a lot of work ennsuring Docker works correctly
   * `docker:20.10.17`
 * Install Ansible 2.9.6 (because this is the version in Ubuntu 20.04)
   * Follow the steps in my existing "ansible-docker" project in Luminate/DevOpsPOCs repo
@@ -41,7 +55,9 @@ This means also that SSH keys can go into the user's SSH directory like normal.
 ## Secondary Requirements
 
 * Bind mount in host Git config
+  * Support the location of this config for both Mac, Liux & Windows
 * Bind mount in SSH keys
+  * * Support the location of this config for both Mac, Liux & Windows
 * Ensure that we can utilise Git from within the Dev Container
 
 ## Building Requiremets
@@ -60,6 +76,7 @@ What sort of things will I need to setup in the `devcontainer.json` file?
 ## Questions
 
 * How do you bind mount in the Docker Socket on Windows so that Docker in Docker (DooD) works?
+* 
 
 ## Tutorials
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,6 +32,10 @@ To be able to utilise this, the following pre-requisites need to be satisfied:
   * This must be Molecule version 5.4.0 because in version 6.0.0 they discontinued support for Ansible 2.9 (unless I want to use the latest release of Ansible)
   * If we don't use this specific version of Molecule, PIP will update Ansible
   * [Molecule Docs - Installation](https://molecule.readthedocs.io/en/latest/installation.html#install)
+* Try to install the latest available version of the VS code server program at build time. This is to hopefully improve the start-up time of the contnainer
+  * Without the code-server installed, this will have to be installed everytime the container is started
+  * The performance improvement of doing this will be lost when a newer version of the VS Code Server becomes available, as it will need to be updated upon container initialisation anyway
+  * Might be good to setup an automated pipeline to check for a new version and re-build the docker image if necessary
 
 Be sure to clean up build depenndencies and caches.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -15,6 +15,7 @@ To be able to utilise this, the following pre-requisites need to be satisfied:
 
 ## Useful Documentation on Remote Contaiers
 
+* [Please, everyone, put your entire development environment in Github](https://www-freecodecamp-org.cdn.ampproject.org/v/s/www.freecodecamp.org/news/put-your-dev-env-in-github/amp/?amp_js_v=a2&amp_gsa=1#referrer=https%3A%2F%2Fwww.google.com&amp_tf=From%20%251%24s&ampshare=https%3A%2F%2Fwww.freecodecamp.org%2Fnews%2Fput-your-dev-env-in-github%2F)
 * [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers)
 * [Getting Started with development in Containers](https://code.visualstudio.com/docs/remote/containers-tutorial)
 * [Create a development container](https://code.visualstudio.com/docs/remote/create-dev-container)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,6 +12,7 @@ To be able to utilise this, the following pre-requisites need to be satisfied:
 * VS Code installed
 * Remote Containers extension installed
 * Docker Desktop installed
+* Packer installed
 
 ## Useful Documentation on Remote Contaiers
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -17,6 +17,7 @@ To be able to utilise this, the following pre-requisites need to be satisfied:
 ## Useful Documentation on Remote Contaiers
 
 * [Please, everyone, put your entire development environment in Github](https://www-freecodecamp-org.cdn.ampproject.org/v/s/www.freecodecamp.org/news/put-your-dev-env-in-github/amp/?amp_js_v=a2&amp_gsa=1#referrer=https%3A%2F%2Fwww.google.com&amp_tf=From%20%251%24s&ampshare=https%3A%2F%2Fwww.freecodecamp.org%2Fnews%2Fput-your-dev-env-in-github%2F)
+* [Packer - Getting Started with building Docker images](https://learn.hashicorp.com/collections/packer/docker-get-started)
 * [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers)
 * [Getting Started with development in Containers](https://code.visualstudio.com/docs/remote/containers-tutorial)
 * [Create a development container](https://code.visualstudio.com/docs/remote/create-dev-container)

--- a/devcontainer/devcontaier.json
+++ b/devcontainer/devcontaier.json
@@ -1,0 +1,19 @@
+{
+    "image": "n0sn1b0r/richs-dev-env:latest",
+    "containerUser" : "cayde",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "eamodio.gitlens",
+                "mhutchie.git-graph",
+                "equinusocio.vsc-community-material-theme",
+                "yzhang.markdown-all-in-one",
+                "redhat.vscode-yaml",
+                "sketchbuch.vsc-workspace-sidebar",
+                "mohsen1.prettify-json",
+                "ue.alphabetical-sorter",
+                "redhat.ansible"
+            ]
+        }
+    }
+}

--- a/devcontainer/devcontaier.json
+++ b/devcontainer/devcontaier.json
@@ -1,5 +1,6 @@
 {
-    "image": "n0sn1b0r/richs-dev-env:latest",
+    "name" : "Richs Dev Container",
+    "image" : "n0sn1b0r/richs-dev-env:latest",
     "containerUser" : "cayde",
     "customizations": {
         "vscode": {

--- a/devcontainer/devcontaier.json
+++ b/devcontainer/devcontaier.json
@@ -16,5 +16,8 @@
                 "redhat.ansible"
             ]
         }
-    }
+    },
+    "mounts" : [
+        "source=${localEnv:HOME}/.ssh,target=/home/cayde/.ssh,type=bind,consistency=cached"
+    ]
 }

--- a/packer/ansible/install_ansible.sh
+++ b/packer/ansible/install_ansible.sh
@@ -15,7 +15,9 @@ set -e
 # Add popular Python modules which support Ansibile
 echo "==> Adding Additional Python Modules..."
 python_packages="py3-boto py3-dateutil py3-httplib2 py3-jinja2 py3-paramiko py3-yaml"
-python_modules="boto3 python-dateutil httplib2 Jinja2 paramiko pyyaml ansible-lint"
+# Ansible Lint module doesn't work with Ansible 2.9.6. This module was only installed to support the Ansible VS Code extension, so it's not essential.
+#python_modules="boto3 python-dateutil httplib2 Jinja2 paramiko pyyaml ansible-lint"
+python_modules="boto3 python-dateutil httplib2 Jinja2 paramiko pyyaml"
 pip install ${python_modules}
 
 echo "==> Adding Ansible..."

--- a/packer/ansible/install_ansible.sh
+++ b/packer/ansible/install_ansible.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 
-set -x
-
 echo "==> ANSIBLE SETUP SCRIPT"
 
 echo "Target Ansible version = ${ANSIBLE_VERSION}"
 echo "Target Docker SDK for Python version = ${DOCKER_SDK_VERSION}"
+
+if [[ ! "${ANSIBLE_VERSION}" =~ latest ]]; then
+    ansible_tag="==${ANSIBLE_VERSION}"
+fi
+
+# Exit on non-zero exit codes from this point (no more conditioinal statements allowed)
+set -e
+
+# Add popular Python modules which support Ansibile
+echo "==> Adding Additional Python Modules..."
+python_packages="py3-boto py3-dateutil py3-httplib2 py3-jinja2 py3-paramiko py3-yaml"
+python_modules="boto3 python-dateutil httplib2 Jinja2 paramiko pyyaml"
+pip install ${python_modules}
+
+echo "==> Adding Ansible..."
+pip install "ansible${ansible_tag}"
 
 echo "==> END ANSIBLE SETUP SCRIPT"

--- a/packer/ansible/install_ansible.sh
+++ b/packer/ansible/install_ansible.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo "==> ANSIBLE SETUP SCRIPT"
+
+echo "Target Ansible version = ${ANSIBLE_VERSION}"
+echo "Target Docker SDK for Python version = ${DOCKER_SDK_VERSION}"
+
+echo "==> END ANSIBLE SETUP SCRIPT"

--- a/packer/ansible/install_ansible.sh
+++ b/packer/ansible/install_ansible.sh
@@ -15,7 +15,7 @@ set -e
 # Add popular Python modules which support Ansibile
 echo "==> Adding Additional Python Modules..."
 python_packages="py3-boto py3-dateutil py3-httplib2 py3-jinja2 py3-paramiko py3-yaml"
-python_modules="boto3 python-dateutil httplib2 Jinja2 paramiko pyyaml"
+python_modules="boto3 python-dateutil httplib2 Jinja2 paramiko pyyaml ansible-lint"
 pip install ${python_modules}
 
 echo "==> Adding Ansible..."

--- a/packer/python3/install_python3.sh
+++ b/packer/python3/install_python3.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+echo "==> PYTHON3 SETUP SCRIPT"
+
+echo "Target Python 3 version = ${PYTHON3_VERSION}"
+
+if [[ ! "${PYTHON3_VERSION}" =~ latest ]]; then
+    python3_tag="=${PYTHON3_VERSION}"
+fi
+
+# Exit on non-zero exit codes from this point (no more conditioinal statements allowed)
+set -e
+
+echo "==> Adding build-dependencies..."
+apk --update add --virtual build-dependencies \
+    gcc \
+    musl-dev \
+    libffi-dev \
+    openssl-dev \
+    python3-dev${python3_tag}
+
+echo "==> Adding Python runtime..."
+apk add --no-cache "python3${python3_tag}" py3-pip
+pip install --upgrade pip
+pip install wheel
+pip install python-keyczar
+
+# Add Python support for Docker 
+# TODO: Move this later to be part of the tasks when Docker is installed
+echo "==> Installing Docker SDK for Python..." && \
+pip install "docker"
+
+echo "==> Cleaning up..."
+apk del build-dependencies
+
+echo "==> END PYTHON3 SETUP SCRIPT"

--- a/packer/python3/install_python3.sh
+++ b/packer/python3/install_python3.sh
@@ -30,7 +30,4 @@ pip install python-keyczar
 echo "==> Installing Docker SDK for Python..." && \
 pip install "docker"
 
-echo "==> Cleaning up..."
-apk del build-dependencies
-
 echo "==> END PYTHON3 SETUP SCRIPT"

--- a/packer/richs-dev-env.pkr.hcl
+++ b/packer/richs-dev-env.pkr.hcl
@@ -20,7 +20,7 @@ build {
     "source.docker.dev-env"
   ]
 
-  # Provisioners
+  # PROVISIONERS #
 
   # Update APK package manager & install core system packages
   provisioner "shell" {
@@ -31,6 +31,7 @@ build {
     ]
   }
 
+  # Setup Python 3
   provisioner "shell" {
     environment_vars = [
       "PYTHON3_VERSION=${var.python3_version}"
@@ -38,6 +39,7 @@ build {
     script = "./python3/install_python3.sh"
   }
 
+  # Setup Ansible
   provisioner "shell" {
     environment_vars = [
       "ANSIBLE_VERSION=${var.ansible_version}",
@@ -61,7 +63,7 @@ build {
     ]
   }
 
-  # Post Processors
+  # POST PROCESSORS #
   post-processor "docker-tag" {
     repository = "n0sn1b0r/richs-dev-env"
     tags       = ["latest"]

--- a/packer/richs-dev-env.pkr.hcl
+++ b/packer/richs-dev-env.pkr.hcl
@@ -22,7 +22,24 @@ build {
 
   # Provisioners
   provisioner "shell" {
-    inline = ["echo Running ${var.docker_image} Docker image."]
+    inline = [
+      "echo Running ${var.docker_image} Docker image."
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "apk update",
+      "apk add --no-cache bash"
+    ]
+  }
+
+  provisioner "shell" {
+    environment_vars = [
+      "ANSIBLE_VERSION=${var.ansible_version}",
+      "DOCKER_SDK_VERSION=${var.docker_sdk_python_version}"
+    ]
+    script = "./ansible/install_ansible.sh"
   }
 
   # Post Processors

--- a/packer/richs-dev-env.pkr.hcl
+++ b/packer/richs-dev-env.pkr.hcl
@@ -27,7 +27,7 @@ build {
     inline = [
       "apk update",
       "apk upgrade",
-      "apk add --no-cache bash ca-certificates openssl curl tar openssh-client sshpass git"
+      "apk add --no-cache bash ca-certificates openssl curl tar openssh-client sshpass git shadow"
     ]
   }
 
@@ -41,7 +41,6 @@ build {
   provisioner "shell" {
     environment_vars = [
       "ANSIBLE_VERSION=${var.ansible_version}",
-      "DOCKER_SDK_VERSION=${var.docker_sdk_python_version}"
     ]
     script = "./ansible/install_ansible.sh"
   }

--- a/packer/richs-dev-env.pkr.hcl
+++ b/packer/richs-dev-env.pkr.hcl
@@ -2,19 +2,40 @@ packer {
   required_plugins {
     docker = {
       version = ">= 0.0.7"
-      source = "github.com/hashicorp/docker"
+      source  = "github.com/hashicorp/docker"
     }
   }
 }
 
-source "docker" "ubuntu" {
-  image  = "ubuntu:jammy"
+# Variables
+variable "docker_image" {
+  type        = string
+  description = "The base Docker image to start from"
+  default     = "alpine:3"
+}
+
+# Sources
+source "docker" "container" {
+  image  = var.docker_image
   commit = true
 }
 
+# Build
 build {
-  name    = "learn-packer"
+  name = "learn-packer"
   sources = [
-    "source.docker.ubuntu"
+    "source.docker.container"
   ]
+
+  # Provisioners
+  provisioner "shell" {
+    inline = ["echo Running ${var.docker_image} Docker image."]
+  }
+
+  # Post Processors
+  post-processor "docker-tag" {
+    repository = "n0sn1b0r/richs-dev-env"
+    tags       = ["latest"]
+    force      = true
+  }
 }

--- a/packer/richs-dev-env.pkr.hcl
+++ b/packer/richs-dev-env.pkr.hcl
@@ -27,7 +27,7 @@ build {
     inline = [
       "apk update",
       "apk upgrade",
-      "apk add --no-cache bash ca-certificates openssl curl tar openssh-client sshpass git shadow"
+      "apk add --no-cache bash ca-certificates openssl curl tar openssh-client sshpass git shadow packer"
     ]
   }
 

--- a/packer/richs-dev-env.pkr.hcl
+++ b/packer/richs-dev-env.pkr.hcl
@@ -26,6 +26,7 @@ build {
   provisioner "shell" {
     inline = [
       "apk update",
+      "apk upgrade",
       "apk add --no-cache bash ca-certificates openssl curl tar openssh-client sshpass git"
     ]
   }
@@ -48,8 +49,16 @@ build {
   # Clearing out package caches
   provisioner "shell" {
     inline = [
+      "apk del build-dependencies",
       "rm -rf /var/cache/apk/*",
       "rm -rf /root/.cache/pip/*"
+    ]
+  }
+
+  # Create step-down user
+  provisioner "shell" {
+    inline = [
+      "adduser -D -s /bin/bash cayde"
     ]
   }
 

--- a/packer/richs-dev-env.pkr.hcl
+++ b/packer/richs-dev-env.pkr.hcl
@@ -7,13 +7,6 @@ packer {
   }
 }
 
-# Variables
-variable "docker_image" {
-  type        = string
-  description = "The base Docker image to start from"
-  default     = "alpine:3"
-}
-
 # Sources
 source "docker" "container" {
   image  = var.docker_image

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -1,3 +1,6 @@
+# variables.pkr.hcl files are used to define variables which are settable at runtime.
+# This includes descriptions and suitable defaults for the case when the user doesn't specify a variable's value at runtime.
+
 # Variables
 variable "docker_image" {
   type        = string

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -25,3 +25,9 @@ variable "docker_ce_version" {
   description = "Version of Docker CE"
   default     = "latest"
 }
+
+variable "python3_version" {
+  type        = string
+  description = "Version of Python 3"
+  default     = "latest"
+}

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -1,0 +1,18 @@
+# Variables
+variable "docker_image" {
+  type        = string
+  description = "The base Docker image to start from"
+  default     = "alpine:3"
+}
+
+variable "ansible_version" {
+  type        = string
+  description = "Version of Ansible to install"
+  default     = "latest"
+}
+
+variable "docker_ce_version" {
+  type        = string
+  description = "Version of Docker CE to install"
+  default     = "latest"
+}

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -7,12 +7,18 @@ variable "docker_image" {
 
 variable "ansible_version" {
   type        = string
-  description = "Version of Ansible to install"
+  description = "Version of Ansible"
+  default     = "latest"
+}
+
+variable "docker_sdk_python_version" {
+  type        = string
+  description = "Version of Docker SDK for Python"
   default     = "latest"
 }
 
 variable "docker_ce_version" {
   type        = string
-  description = "Version of Docker CE to install"
+  description = "Version of Docker CE"
   default     = "latest"
 }

--- a/packer/variables.pkrvars.hcl
+++ b/packer/variables.pkrvars.hcl
@@ -1,6 +1,6 @@
 # variables.pckvars.hcl files are declarations of variables and the values to set them to at runtime.
 # Only variables defined in *.pck.hcl files can be declared in *.pckvars.hcl files.
 
-ansible_version           = "2.9.6"
-docker_ce_version         = "20.10.17"
-docker_image              = "alpine:3"
+ansible_version   = "2.9.6"
+docker_ce_version = "20.10.17"
+docker_image      = "alpine:3"

--- a/packer/variables.pkrvars.hcl
+++ b/packer/variables.pkrvars.hcl
@@ -1,0 +1,1 @@
+docker_image = "alpine:3"

--- a/packer/variables.pkrvars.hcl
+++ b/packer/variables.pkrvars.hcl
@@ -1,3 +1,6 @@
+# variables.pckvars.hcl files are declarations of variables and the values to set them to at runtime.
+# Only variables defined in *.pck.hcl files can be declared in *.pckvars.hcl files.
+
 ansible_version           = "2.9.6"
 docker_ce_version         = "20.10.17"
 docker_image              = "alpine:3"

--- a/packer/variables.pkrvars.hcl
+++ b/packer/variables.pkrvars.hcl
@@ -1,1 +1,4 @@
-docker_image = "alpine:3"
+ansible_version           = "2.9.6"
+docker_ce_version         = "20.10.17"
+docker_image              = "alpine:3"
+docker_sdk_python_version = "4.4.4"

--- a/packer/variables.pkrvars.hcl
+++ b/packer/variables.pkrvars.hcl
@@ -4,4 +4,3 @@
 ansible_version           = "2.9.6"
 docker_ce_version         = "20.10.17"
 docker_image              = "alpine:3"
-docker_sdk_python_version = "4.4.4"


### PR DESCRIPTION
Might as well get this work in to main now.

Current functionality:

* Packer builds a Docker image
* Docker image contains:
   * Python 3
   * Packer
   * Ansible
* Dev Container JSON file defined
* Some extensions added
* Local user's SSH directory is bind mounted in

Considerations:

* Support is questionable on Windows, mainly because I'm not sure the bind mount off the SSH directory will work the same